### PR TITLE
Enable F1-F15 hotkeys for actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,15 @@ The application will connect to OBS using the environment variables above. For e
 ```bash
 OBS_HOST=192.168.1.2 OBS_PASSWORD=secret python main.py
 ```
+
+## Hotkeys
+
+When running the GUI, global hotkeys for **F1** through **F15** are registered.
+Each function key corresponds to the buttons shown in the interface in order:
+`F1` → Enc 1, `F2` → Enc 2, `F3` → Enc 3, `F4` → Key 1 and so on.
+Pressing one of these keys will trigger the assigned action without clicking the
+GUI button.
+
+On Linux systems the `keyboard` module may require elevated privileges to
+capture global events. If the hotkeys do not work, try running the application
+with `sudo` or as an administrator.

--- a/gui.py
+++ b/gui.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 from obs_client import OBSClient
 import os
+import keyboard
 
 class KeyButton(tk.Canvas):
     def __init__(self, master, label):
@@ -142,6 +143,9 @@ class KeyboardGUI(tk.Tk):
 
         self.selected_key = None
 
+        # Register global hotkeys for each button
+        self.setup_hotkeys()
+
     def select_key(self, key_btn):
         self.selected_key = key_btn
         print(f"Selected {key_btn.label}")
@@ -152,6 +156,13 @@ class KeyboardGUI(tk.Tk):
         action_name = self.action_var.get()
         if action_name:
             self.selected_key.assign(action_name, self.actions[action_name])
+
+    def setup_hotkeys(self):
+        """Bind F1–F15 to the corresponding buttons."""
+        for idx, key_btn in enumerate(self.keys):
+            hotkey = f"f{idx + 1}"
+            keyboard.add_hotkey(hotkey, key_btn.trigger)
+        print("⌨️ Hotkeys registered: F1–F15")
 
     def run(self):
         self.mainloop()


### PR DESCRIPTION
## Summary
- register global hotkeys via `keyboard` in the GUI
- document the new F1–F15 hotkeys and privilege requirement

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68551369ac00832887e4bdbd7d16bbf8