### PR TITLE
Add ability to run custom programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,11 @@ Pressing one of these keys will trigger the assigned action without clicking the
 On Linux systems the `keyboard` module may require elevated privileges to
 capture global events. If the hotkeys do not work, try running the application
 with `sudo` or as an administrator.
+
+## Custom programs
+
+Buttons can launch your own programs. Select a key in the GUI, choose
+**Run Program** in the action list and enter the command in the *Command*
+field. After clicking **Assign**, pressing the button (or its hotkey) will run
+the command via the system shell. For example, entering `firefox` will launch
+the Firefox browser.


### PR DESCRIPTION
## Summary
- allow assigning a custom command to any key
- run that command via `subprocess.Popen`
- document how to assign custom programs

## Testing
- `pytest -q`
- `python -m py_compile main.py key_handler.py obs_client.py gui.py`

------
https://chatgpt.com/codex/tasks/task_e_68551dc9295c832897cc5f56c2109be4