### PR TITLE
Update layout to 5x3 grid with centered encoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ OBS_HOST=192.168.1.2 OBS_PASSWORD=secret python main.py
 
 ## Hotkeys
 
+The interface now shows fifteen keys in a 5×3 grid with three encoder controls placed in the middle row.
 When running the GUI, global hotkeys for **F13** through **F24** are registered for the numbered keys.
-Each function key corresponds to the buttons shown in the interface in order: `F13` → Key 1, `F14` → Key 2 and so on.
+Each function key corresponds to the keys in order: `F13` → Key 1, `F14` → Key 2 and so on.
 Pressing one of these keys will trigger the assigned action without clicking the GUI button.
 
 On Linux systems the `keyboard` module may require elevated privileges to

--- a/gui.py
+++ b/gui.py
@@ -67,7 +67,7 @@ class KeyboardGUI(tk.Tk):
     def __init__(self):
         super().__init__()
         self.title("QMK Keyboard Controller")
-        self.geometry("600x400")
+        self.geometry("700x400")
         self.resizable(False, False)
         self.configure(bg="#121212")
 
@@ -117,22 +117,38 @@ class KeyboardGUI(tk.Tk):
         self.keyboard_frame.pack(side=tk.LEFT, padx=10)
 
         self.keys = []
-        # Encoders on top row
+        self.encoders = []
+        # Encoders centered on middle row
         for i in range(3):
             btn = KeyButton(self.keyboard_frame, f"Enc {i+1}")
-            btn.grid(row=0, column=i, padx=5, pady=5)
+            btn.grid(row=1, column=i+1, padx=5, pady=5)
             btn.bind('<Button-1>', lambda e, b=btn: self.select_key(b))
+            self.encoders.append(btn)
             self.keys.append(btn)
 
-        # 12 keys (3x4 grid)
+        # 12 keys arranged 5x3 around encoders
         index = 1
-        for r in range(1,5):
-            for c in range(3):
-                btn = KeyButton(self.keyboard_frame, f"Key {index}")
-                btn.grid(row=r, column=c, padx=5, pady=5)
-                btn.bind('<Button-1>', lambda e, b=btn: self.select_key(b))
-                self.keys.append(btn)
-                index += 1
+        # Top row
+        for c in range(5):
+            btn = KeyButton(self.keyboard_frame, f"Key {index}")
+            btn.grid(row=0, column=c, padx=5, pady=5)
+            btn.bind('<Button-1>', lambda e, b=btn: self.select_key(b))
+            self.keys.append(btn)
+            index += 1
+        # Middle row edges
+        for c in (0, 4):
+            btn = KeyButton(self.keyboard_frame, f"Key {index}")
+            btn.grid(row=1, column=c, padx=5, pady=5)
+            btn.bind('<Button-1>', lambda e, b=btn: self.select_key(b))
+            self.keys.append(btn)
+            index += 1
+        # Bottom row
+        for c in range(5):
+            btn = KeyButton(self.keyboard_frame, f"Key {index}")
+            btn.grid(row=2, column=c, padx=5, pady=5)
+            btn.bind('<Button-1>', lambda e, b=btn: self.select_key(b))
+            self.keys.append(btn)
+            index += 1
 
         # Sidebar for actions
         sidebar = tk.Frame(content, bg="#121212")


### PR DESCRIPTION
## Summary
- make window slightly wider
- arrange GUI buttons into a 5x3 grid
- center encoder controls on the middle row
- document new layout in README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6855467a0dc4832881feb775dee0dcb6