### PR TITLE
Remove start/stop actions, keep toggles only

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ the Firefox browser. To open the system default browser you can use
 
 ## OBS actions
 
-Alongside dedicated Start/Stop options, the action list now includes
-**Toggle Stream** and **Toggle Recording** which start or stop the corresponding
-OBS outputs on repeated presses. The **Toggle Filter** action allows selecting
-a source and filter from OBS and toggling it with a single key.
+The action list includes **Toggle Stream** and **Toggle Recording** which start
+or stop the corresponding OBS outputs on repeated presses. The **Toggle Filter**
+action allows selecting a source and filter from OBS and toggling it with a
+single key.
 
 ## Tray mode
 

--- a/gui.py
+++ b/gui.py
@@ -156,11 +156,7 @@ class KeyboardGUI(tk.Tk):
         tk.Label(sidebar, text="Action", fg="white", bg="#121212").pack(pady=5)
 
         actions = {
-            "Start Stream": self.obs.start_streaming,
-            "Stop Stream": self.obs.stop_streaming,
             "Toggle Stream": self.obs.toggle_streaming,
-            "Start Recording": self.obs.start_recording,
-            "Stop Recording": self.obs.stop_recording,
             "Toggle Recording": self.obs.toggle_recording,
             "Toggle Mic": self.obs.toggle_mic,
             "Scene 1": lambda: self.obs.set_scene("Scene 1"),

--- a/key_handler.py
+++ b/key_handler.py
@@ -7,8 +7,7 @@ def setup_keybindings(obs_client):
     keyboard.add_hotkey('f1', lambda: obs_client.set_scene('Scene 1'))
     keyboard.add_hotkey('f2', lambda: obs_client.set_scene('Scene 2'))
     keyboard.add_hotkey('f3', lambda: obs_client.toggle_mic())
-    keyboard.add_hotkey('f4', lambda: obs_client.start_recording())
-    keyboard.add_hotkey('f5', lambda: obs_client.stop_recording())
+    keyboard.add_hotkey('f4', lambda: obs_client.toggle_recording())
 
     print("⌨️ Hotkeys are active (press ESC to stop)...")
     while True:


### PR DESCRIPTION
## Summary
- streamline OBS action list to only provide toggle functions
- update hotkey examples accordingly
- clarify README description

## Testing
- `python -m py_compile gui.py main.py obs_client.py key_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_685551b658748328aa6fb1e2e7ef136c