### PR TITLE
Adjust layout so encoders sit above keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ OBS_HOST=192.168.1.2 OBS_PASSWORD=secret python main.py
 
 ## Hotkeys
 
-The interface now shows fifteen keys in a 5×3 grid with three encoder controls placed in the middle row.
+The interface now shows fifteen keys in a 5×3 grid with three encoder controls positioned on a row above the keys.
 When running the GUI, global hotkeys for **F13** through **F24** are registered for the numbered keys.
 Each function key corresponds to the keys in order: `F13` → Key 1, `F14` → Key 2 and so on.
 Pressing one of these keys will trigger the assigned action without clicking the GUI button.

--- a/gui.py
+++ b/gui.py
@@ -118,37 +118,23 @@ class KeyboardGUI(tk.Tk):
 
         self.keys = []
         self.encoders = []
-        # Encoders centered on middle row
+        # Encoders on a dedicated top row
         for i in range(3):
             btn = KeyButton(self.keyboard_frame, f"Enc {i+1}")
-            btn.grid(row=1, column=i+1, padx=5, pady=5)
+            btn.grid(row=0, column=i+1, padx=5, pady=5)
             btn.bind('<Button-1>', lambda e, b=btn: self.select_key(b))
             self.encoders.append(btn)
             self.keys.append(btn)
 
-        # 12 keys arranged 5x3 around encoders
+        # 15 keys in three rows below the encoders
         index = 1
-        # Top row
-        for c in range(5):
-            btn = KeyButton(self.keyboard_frame, f"Key {index}")
-            btn.grid(row=0, column=c, padx=5, pady=5)
-            btn.bind('<Button-1>', lambda e, b=btn: self.select_key(b))
-            self.keys.append(btn)
-            index += 1
-        # Middle row edges
-        for c in (0, 4):
-            btn = KeyButton(self.keyboard_frame, f"Key {index}")
-            btn.grid(row=1, column=c, padx=5, pady=5)
-            btn.bind('<Button-1>', lambda e, b=btn: self.select_key(b))
-            self.keys.append(btn)
-            index += 1
-        # Bottom row
-        for c in range(5):
-            btn = KeyButton(self.keyboard_frame, f"Key {index}")
-            btn.grid(row=2, column=c, padx=5, pady=5)
-            btn.bind('<Button-1>', lambda e, b=btn: self.select_key(b))
-            self.keys.append(btn)
-            index += 1
+        for r in range(1, 4):
+            for c in range(5):
+                btn = KeyButton(self.keyboard_frame, f"Key {index}")
+                btn.grid(row=r, column=c, padx=5, pady=5)
+                btn.bind('<Button-1>', lambda e, b=btn: self.select_key(b))
+                self.keys.append(btn)
+                index += 1
 
         # Sidebar for actions
         sidebar = tk.Frame(content, bg="#121212")


### PR DESCRIPTION
## Summary
- place encoders in a dedicated top row
- arrange the keys in three rows below the encoders
- update docs to describe encoders above the keys

## Testing
- `python -m py_compile main.py gui.py key_handler.py obs_client.py`

------
https://chatgpt.com/codex/tasks/task_e_68555981658c832893f4ac8e04748b37