### PR TITLE
Allow running without OBS and fix hotkey range

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -83,7 +83,7 @@ class KeyboardGUI(tk.Tk):
 
         self.tray_icon = self.create_tray_icon()
 
-        # Connect to OBS
+        # Initialize OBS client but don't require connection on startup
         self.obs = OBSClient(
             host=os.getenv("OBS_HOST", "localhost"),
             port=int(os.getenv("OBS_PORT", 4455)),
@@ -92,22 +92,7 @@ class KeyboardGUI(tk.Tk):
         try:
             self.obs.connect()
         except Exception as e:
-            print(f"OBS connection error: {e}")
-            msg = (
-                "Failed to connect to OBS.\n"
-                "1. Ensure OBS is running and the WebSocket server is enabled.\n"
-                "2. Verify the host and port settings.\n"
-                "3. Check the WebSocket password."
-            )
-            retry = messagebox.askretrycancel("OBS Connection Error", msg)
-            if retry:
-                try:
-                    self.obs.connect()
-                except Exception:
-                    messagebox.showerror(
-                        "Connection Failed",
-                        "Still unable to connect. Please review your settings."
-                    )
+            print(f"OBS connection error: {e}. Will retry when actions are used.")
 
         content = tk.Frame(self, bg="#121212")
         content.pack(fill=tk.BOTH, expand=True)
@@ -344,8 +329,8 @@ class KeyboardGUI(tk.Tk):
                 btn.assign(action, self.actions.get(action))
 
     def setup_hotkeys(self):
-        """Bind F13–F24 to the main 12 keys."""
-        for idx, key_btn in enumerate(self.keys[3:], start=13):
+        """Bind F13–F24 to the first 12 numbered keys."""
+        for idx, key_btn in enumerate(self.keys[3:15], start=13):
             hotkey = f"f{idx}"
             keyboard.add_hotkey(hotkey, key_btn.trigger)
         print("⌨️ Hotkeys registered: F13–F24")

--- a/obs_client.py
+++ b/obs_client.py
@@ -11,46 +11,75 @@ class OBSClient:
         password = password if password is not None else os.getenv("OBS_PASSWORD", "")
 
         self.ws = obsws(host, port, password)
+        self.connected = False
     
     def connect(self):
         self.ws.connect()
+        self.connected = True
         print("✅ Connected to OBS WebSocket")
     
     def disconnect(self):
-        self.ws.disconnect()
-        print("❌ Disconnected from OBS WebSocket")
+        if self.connected:
+            self.ws.disconnect()
+            self.connected = False
+            print("❌ Disconnected from OBS WebSocket")
+
+    def ensure_connection(self):
+        if not self.connected:
+            try:
+                self.connect()
+            except Exception as e:
+                print(f"OBS connection failed: {e}")
+                return False
+        return True
     
     def set_scene(self, scene_name):
+        if not self.ensure_connection():
+            return
         self.ws.call(requests.SetCurrentProgramScene(sceneName=scene_name))
         print(f"🎬 Switched to scene: {scene_name}")
     
     def toggle_mic(self):
+        if not self.ensure_connection():
+            return
         self.ws.call(requests.ToggleInputMute(inputName='Mic/Aux'))
         print("🎙️ Toggled Mic Mute")
     
     def start_recording(self):
+        if not self.ensure_connection():
+            return
         self.ws.call(requests.StartRecord())
         print("⏺️ Recording Started")
 
     def stop_recording(self):
+        if not self.ensure_connection():
+            return
         self.ws.call(requests.StopRecord())
         print("⏹️ Recording Stopped")
 
     def start_streaming(self):
+        if not self.ensure_connection():
+            return
         self.ws.call(requests.StartStreaming())
         print("📡 Streaming Started")
 
     def stop_streaming(self):
+        if not self.ensure_connection():
+            return
         self.ws.call(requests.StopStreaming())
         print("🛑 Streaming Stopped")
 
     def toggle_streaming(self):
         """Start or stop streaming depending on current state."""
+        if not self.ensure_connection():
+            return
         self.ws.call(requests.ToggleStream())
         print("🔀 Streaming Toggled")
 
     def toggle_filter(self, source_name, filter_name):
         # Retrieve current filter state
+        if not self.ensure_connection():
+            return
         resp = self.ws.call(requests.GetSourceFilter(sourceName=source_name, filterName=filter_name))
         current_state = resp.datain.get("filterEnabled")
 
@@ -69,17 +98,23 @@ class OBSClient:
 
     def toggle_recording(self):
         """Start or stop recording depending on current state."""
+        if not self.ensure_connection():
+            return
         self.ws.call(requests.ToggleRecord())
         print("🔀 Recording Toggled")
 
     def list_inputs(self):
         """Return a list of available input names."""
+        if not self.ensure_connection():
+            return []
         resp = self.ws.call(requests.GetInputList())
         inputs = resp.datain.get("inputs", [])
         return [i.get("inputName") for i in inputs]
 
     def list_filters(self, source_name):
         """Return filter names for the given source."""
+        if not self.ensure_connection():
+            return []
         resp = self.ws.call(requests.GetSourceFilterList(sourceName=source_name))
         filters = resp.datain.get("filters", [])
         return [f.get("filterName") for f in filters]


### PR DESCRIPTION
## Summary
- initialize OBS connection lazily
- auto-connect when OBS actions are triggered
- register only F13–F24 hotkeys so F25+ are not used

## Testing
- `python -m py_compile *.py`
- `pip install -r requirements.txt` *(fails: GUI run requires display)*
- `python main.py` *(fails: DisplayNameError from pystray because no display)*

------
https://chatgpt.com/codex/tasks/task_e_68555f7c31ac8328b04b157e1db607dc