### PR TITLE
Update README with CGO build info

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ The Go version can be built from the `golang` directory:
 cd golang && go build
 ```
 
+Fyne relies on the `go-gl` OpenGL bindings which use CGO. Building the Go
+version therefore requires a working C compiler, such as GCC on Linux or
+MinGW-w64 on Windows. Make sure `CGO_ENABLED=1` is set when running `go build`
+or `go run`.
+
 ## Hotkeys
 
 The interface now shows fifteen keys in a 5×3 grid with three encoder controls positioned on a row above the keys.


### PR DESCRIPTION
## Summary
- document CGO requirements when building the Go version

## Testing
- `python -m py_compile *.py`
- `go build ./...` *(fails: missing X11 headers)*

------
https://chatgpt.com/codex/tasks/task_e_685d30672da08328a24d2535be8ca48e