### PR TITLE
Add draggable custom title bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,10 @@ single key.
 When the GUI window is minimized or closed, it hides and a small tray icon
 appears. Right-click this icon to reopen the window or quit the application.
 Choosing **Quit** disconnects from OBS before exiting.
+
+## Customization
+
+The application uses a custom title bar with its own window controls. Buttons for
+minimize, maximize and close sit at the top right. Hovering over them highlights
+the background. Drag the title bar to move the window. Maximizing toggles between
+full screen and the previous size.


### PR DESCRIPTION
## Summary
- remove window manager frame and create a custom title bar
- implement minimize, maximize and close buttons with hover effects
- allow moving the window by dragging the title bar
- document the new custom title bar in the README

## Testing
- `python -m py_compile gui.py key_handler.py main.py obs_client.py`

------
https://chatgpt.com/codex/tasks/task_e_685d347e3a0c8328b41380aa7eebe5bd