### PR TITLE
Improve tray behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ single key.
 ## Tray mode
 
 When the GUI window is minimized or closed, it hides and a small tray icon
-appears. Right-click this icon to reopen the window or quit the application.
-Choosing **Quit** disconnects from OBS before exiting.
+appears. Double-click the icon to restore the window. You can also
+right-click it to access a menu with **Open** and **Quit** actions. Choosing
+**Quit** disconnects from OBS before exiting.
 
 ## Customization
 


### PR DESCRIPTION
## Summary
- ensure custom window shows in the taskbar
- support double‑clicking tray icon to reopen window
- document tray icon behaviour

## Testing
- `python -m py_compile gui.py obs_client.py key_handler.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_685d382a3a2883289b1fd176d31732b2